### PR TITLE
chore: @formspree/react use latest (local) @formspree/core

### DIFF
--- a/packages/formspree-react/package.json
+++ b/packages/formspree-react/package.json
@@ -31,7 +31,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@formspree/core": "^2.8.1",
+    "@formspree/core": "*",
     "@stripe/react-stripe-js": "^1.7.1",
     "@stripe/stripe-js": "^1.35.0"
   },


### PR DESCRIPTION
Use `*` version to use the local version of @formspree/core in @formspree/react.

See why: https://turbo.build/repo/docs/handbook/workspaces#workspaces-which-depend-on-each-other

> The `*` allows us to reference the latest version of the dependency. It saves us from needing to bump the versions of our dependency if the versions of our packages change.