### PR TITLE
feature: (type) support array as field value

### DIFF
--- a/.changeset/gorgeous-dogs-sniff.md
+++ b/.changeset/gorgeous-dogs-sniff.md
@@ -1,0 +1,6 @@
+---
+'@formspree/core': patch
+'@formspree/react': patch
+---
+
+(type) Support array as FieldValue

--- a/packages/formspree-core/src/submission.ts
+++ b/packages/formspree-core/src/submission.ts
@@ -3,10 +3,8 @@ import type { UnknownObject } from './utils';
 
 export type SubmissionData<T extends FieldValues = FieldValues> = FormData | T;
 
-export type FieldValues = Record<
-  string,
-  string | number | boolean | null | undefined
->;
+export type FieldValues = Record<string, FieldValue | FieldValue[]>;
+type FieldValue = string | number | boolean | null | undefined;
 
 export type SubmissionOptions = {
   clientName?: string;


### PR DESCRIPTION
Formspree supports arrays in form submission data.

This PR updates `FieldValues` types in `@formspree/core` to allow passing `Array<string | number | boolean | null | undefined>` as a field value.