### PR TITLE
Bump (patch) @formspree/core and @formspree/react to fix the release pipeline

### DIFF
--- a/.changeset/curly-insects-joke.md
+++ b/.changeset/curly-insects-joke.md
@@ -1,0 +1,6 @@
+---
+'@formspree/core': patch
+'@formspree/react': patch
+---
+
+Bump (patch) @formspree/core and @formspree/react to fix the release pipeline


### PR DESCRIPTION
Our release pipeline is failing due to a previous failing release (Version Packages (#59)). https://github.com/formspree/formspree-js/actions/runs/10109766685/job/27958780998

Bump a patch version to try to solve it.