### PR TITLE
Fix: Stripe not working on @formspree/react

### DIFF
--- a/.changeset/shiny-pears-know.md
+++ b/.changeset/shiny-pears-know.md
@@ -1,0 +1,5 @@
+---
+'@formspree/react': minor
+---
+
+Fix: Stripe not working on @formspree/react

--- a/packages/formspree-react/src/context.tsx
+++ b/packages/formspree-react/src/context.tsx
@@ -8,6 +8,7 @@ import React, {
   useState,
   type ReactNode,
 } from 'react';
+import { StripeProvider } from './stripe';
 
 export type FormspreeContextType = {
   client: Client;
@@ -62,7 +63,9 @@ export function FormspreeProvider(props: FormspreeProviderProps) {
   return (
     <FormspreeContext.Provider value={{ client }}>
       {stripePromise ? (
-        <Elements stripe={stripePromise}>{children}</Elements>
+        <Elements stripe={stripePromise}>
+          <StripeProvider>{children}</StripeProvider>
+        </Elements>
       ) : (
         children
       )}

--- a/packages/formspree-react/src/stripe.tsx
+++ b/packages/formspree-react/src/stripe.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useElements } from '@stripe/react-stripe-js';
+import type { StripeElements } from '@stripe/stripe-js';
+import { createContext, useContext, type PropsWithChildren } from 'react';
+
+type StripeContextValue = {
+  elements: StripeElements | null;
+};
+
+const StripeContext = createContext<StripeContextValue>({ elements: null });
+
+export function StripeProvider(props: PropsWithChildren) {
+  const { children } = props;
+  const elements = useElements();
+  return (
+    <StripeContext.Provider value={{ elements }}>
+      {children}
+    </StripeContext.Provider>
+  );
+}
+
+export function useStripeContext(): StripeContextValue {
+  return useContext(StripeContext);
+}


### PR DESCRIPTION
Root cause: `stripe?.elements().getElement(CardElement)` always return `null` since `stripe.elements()` creates a new instance of `Elements`; resulted in `createPaymentMethod` was always `undefined`.

This issue arose because React hooks like `useElements` cannot be called conditionally. Calling `useElements` unconditionally will cause errors for users who don't use Stripe.

This PR wraps `useElements` call in a **conditionally rendered** component `StripeProvider` to pass the correct `elements` instance down via context, so we can get `cardElement` from it.